### PR TITLE
Reduced simulation time of ex 1 and fix documentation build warnings

### DIFF
--- a/docs/src/manual/1.-Basic-potential-flow-problem.md
+++ b/docs/src/manual/1.-Basic-potential-flow-problem.md
@@ -47,6 +47,14 @@ The discrete streamfunction `s` is then obtained using `computeψ`.
 
 ```@example 1.-Basic-potential-flow-problem
 s = computeψ(model);
+nothing #hide
+```
+
+```@setup 1.-Basic-potential-flow-problem
+ENV["GKSwstype"] = "nul"
+```
+
+```@example 1.-Basic-potential-flow-problem
 using Plots
 plot(s,g,xlabel="x",ylabel="y")
 ```
@@ -196,12 +204,12 @@ plot!((X->X[1]).(X_hist),(X->X[3]).(X_hist),color=:blue,xlabel="x",ylabel="y")
 ```
 
 ## Corotating vortex patches
-A more complex example is the evolution of two circular regions of spatially uniform vorticity that have an equal radius $r_0$ and strength $\Gamma$, and whose centers are separated by a distance $d_0$. Note that if these were two point vortices, their period would be equal to $2 {\pi}^2 {d_0}^2 / \Gamma_0$, so we will take the final time of our simulation equal to some multiple of this to ensure it includes a couple of periods.
+A more complex example is the evolution of two circular regions of spatially uniform vorticity that have an equal radius $r_0$ and strength $\Gamma$, and whose centers are separated by a distance $d_0$. Note that if these were two point vortices, their period would be equal to $2 {\pi}^2 {d_0}^2 / \Gamma_0$, so we will take the final time of our simulation equal to this to ensure it includes one period.
 
 ```@example 1.-Basic-potential-flow-problem
 Γ0 = 1.0;
 d0 = 1.0;
-tf = 4*π^2*d0^2/Γ0;
+tf = 2*π^2*d0^2/Γ0;
 tspan = (0.0,tf);
 nothing #hide
 ```
@@ -228,7 +236,7 @@ vortexpatch(xc,yc,Γ,radius,nring::Int) = vortexpatch!(Vortex[],xc,yc,Γ,radius,
 ```@setup 1.-Basic-potential-flow-problem
 xlim = (-2,2);
 ylim = (-2,2);
-Δx = 0.02;
+Δx = 0.05;
 g = PhysicalGrid(xlim,ylim,Δx);
 ```
 

--- a/docs/src/manual/2.-Potential-flow-with-an-impenetrable-surface.md
+++ b/docs/src/manual/2.-Potential-flow-with-an-impenetrable-surface.md
@@ -34,8 +34,10 @@ This problem has the structure of a generic saddle-point problem and we will enc
 
 We will now consider two examples. In these examples, we use the following grid.
 ```@setup 2.-Potential-flow-with-an-impenetrable-surface
+ENV["GKSwstype"] = "nul"
 using GridPotentialFlow
 using Plots
+```
 ```
 
 ```@example 2.-Potential-flow-with-an-impenetrable-surface

--- a/docs/src/manual/3.-Non-uniqueness-and-discrete-circulation.md
+++ b/docs/src/manual/3.-Non-uniqueness-and-discrete-circulation.md
@@ -22,6 +22,7 @@ and the circulation can be specified in `ModelParameters`. If it is not specifie
 We now illustrate how to specify the circulation by simulating the flow around two cylinders that have different circulations.
 
 ```@setup 3.-Non-uniqueness-and-discrete-circulation
+ENV["GKSwstype"] = "nul"
 using GridPotentialFlow
 using Plots
 ```

--- a/docs/src/manual/4.-The-Kutta-condition.md
+++ b/docs/src/manual/4.-The-Kutta-condition.md
@@ -8,6 +8,7 @@ For surfaces that contain convex edges, the vortex sheet strength assumes a sing
 
 Let's illustrate this with the example of a flat plate. First create the grid.
 ```@setup 4.-The-Kutta-condition
+ENV["GKSwstype"] = "nul"
 using GridPotentialFlow
 using Plots
 ```

--- a/docs/src/manual/5.-Generalized-edge-conditions.md
+++ b/docs/src/manual/5.-Generalized-edge-conditions.md
@@ -18,6 +18,7 @@ If $\mathfrak{e}_{k}^T\tilde{\mathfrak{f}}^*$ lies within this range, then no ne
 
 Let's illustrate this again with the example of a flat plate. To clearly show the effect of varying the suction parameter, we will run a simulation of the vortex shedding for a couple of time steps for three different suction parameter ranges. First we create the grid and the flate plate.
 ```@setup 5.-Generalized-edge-conditions
+ENV["GKSwstype"] = "nul"
 using GridPotentialFlow
 using Plots
 ```

--- a/docs/src/manual/6.-Force-and-the-added-mass.md
+++ b/docs/src/manual/6.-Force-and-the-added-mass.md
@@ -27,6 +27,7 @@ See the notebook in the examples folder for the analytical solution.
 
 We use a rectangular grid.
 ```@setup 6.-Force-and-the-added-mass
+ENV["GKSwstype"] = "nul"
 using GridPotentialFlow
 using Plots
 ```

--- a/src/vortexmodel.jl
+++ b/src/vortexmodel.jl
@@ -4,17 +4,13 @@ import LinearAlgebra: Diagonal, norm
 export VortexModel, computeψ, computew, computew!, computevortexvelocities, _computeregularizationmatrix, getstrengths, getpositions, setvortexpositions!, getvortexpositions, setvortices!, pushvortices!, computeimpulse, computeaddedmassmatrix, solvesystem, solvesystem!
 
 # TODO: check if _computeψboundaryconditions needs to be faster
-# TODO: impulse case when U∞ is specified instead of Ub
-# TODO: create PotentialFlowBody type that encapsulates Ub, Γb, and any regularized edges
+# TODO: impulse case when Ub is specified instead of U∞
 # TODO: try to remove _d_kvec from VortexModel
 # TODO: check memory allocation inverse laplacian in ConstrainedSystems
 # TODO: check if TU, TF should be used to enforce type compatibility in functions
-# TODO: add rotation
-# TODO: rotational coefficients of added mass matrix
 # TODO: add examples
 # TODO: mention frame of reference for computeimpulse
 # TODO: check if fk_vec in systems.jl can be simplified
-# TODO: let literate create scripts for testing
 # TODO: consider no deepcopy for new vortices in the methods and use deepcopy in the scripts instead
 # TODO: use Parameters.jl?
 # TODO: consider using StructArray for vortexlist

--- a/test/literate/1.-Basic-potential-flow-problem.jl
+++ b/test/literate/1.-Basic-potential-flow-problem.jl
@@ -34,6 +34,9 @@ model = VortexModel(g,vortices=[v]);
 
 # The discrete streamfunction `s` is then obtained using `computeψ`.
 s = computeψ(model);
+#md # ```@setup 1.-Basic-potential-flow-problem
+#md # ENV["GKSwstype"] = "nul"
+#md # ```
 using Plots
 plot(s,g,xlabel="x",ylabel="y")
 
@@ -155,11 +158,11 @@ plot!((X->X[1]).(X_hist),(X->X[3]).(X_hist),color=:blue,xlabel="x",ylabel="y")
 
 #=
 ## Corotating vortex patches
-A more complex example is the evolution of two circular regions of spatially uniform vorticity that have an equal radius $r_0$ and strength $\Gamma$, and whose centers are separated by a distance $d_0$. Note that if these were two point vortices, their period would be equal to $2 {\pi}^2 {d_0}^2 / \Gamma_0$, so we will take the final time of our simulation equal to some multiple of this to ensure it includes a couple of periods.
+A more complex example is the evolution of two circular regions of spatially uniform vorticity that have an equal radius $r_0$ and strength $\Gamma$, and whose centers are separated by a distance $d_0$. Note that if these were two point vortices, their period would be equal to $2 {\pi}^2 {d_0}^2 / \Gamma_0$, so we will take the final time of our simulation equal to this to ensure it includes one period.
 =#
 Γ0 = 1.0;
 d0 = 1.0;
-tf = 4*π^2*d0^2/Γ0;
+tf = 2*π^2*d0^2/Γ0;
 tspan = (0.0,tf);
 
 # To simulate their evolution, we discretize these vortex patches with point vortices arranged on concentric rings using the following function.
@@ -182,12 +185,12 @@ vortexpatch(xc,yc,Γ,radius,nring::Int) = vortexpatch!(Vortex[],xc,yc,Γ,radius,
 #md # ```@setup 1.-Basic-potential-flow-problem
 #md # xlim = (-2,2);
 #md # ylim = (-2,2);
-#md # Δx = 0.02;
+#md # Δx = 0.05;
 #md # g = PhysicalGrid(xlim,ylim,Δx);
 #md # ```
 #!md xlim = (-2,2);
 #!md ylim = (-2,2);
-#!md Δx = 0.02;
+#!md Δx = 0.05;
 #!md g = PhysicalGrid(xlim,ylim,Δx);
 
 # In our last example, we implemented a forward Euler time stepping routine. In this example, we will make use of the fourth-order Runge-Kutta time stepping algorithm of `OrdinaryDiffEq.jl` to get more accurate results.

--- a/test/literate/2.-Potential-flow-with-an-impenetrable-surface.jl
+++ b/test/literate/2.-Potential-flow-with-an-impenetrable-surface.jl
@@ -32,8 +32,10 @@ This problem has the structure of a generic saddle-point problem and we will enc
 
 # We will now consider two examples. In these examples, we use the following grid.
 #md # ```@setup 2.-Potential-flow-with-an-impenetrable-surface
+#md # ENV["GKSwstype"] = "nul"
 #md # using GridPotentialFlow
 #md # using Plots
+#md # ```
 #md # ```
 #!md using GridPotentialFlow
 #!md using Plots

--- a/test/literate/3.-Non-uniqueness-and-discrete-circulation.jl
+++ b/test/literate/3.-Non-uniqueness-and-discrete-circulation.jl
@@ -20,6 +20,7 @@ and the circulation can be specified in `ModelParameters`. If it is not specifie
 # We now illustrate how to specify the circulation by simulating the flow around two cylinders that have different circulations.
 
 #md # ```@setup 3.-Non-uniqueness-and-discrete-circulation
+#md # ENV["GKSwstype"] = "nul"
 #md # using GridPotentialFlow
 #md # using Plots
 #md # ```

--- a/test/literate/4.-The-Kutta-condition.jl
+++ b/test/literate/4.-The-Kutta-condition.jl
@@ -6,6 +6,7 @@ For surfaces that contain convex edges, the vortex sheet strength assumes a sing
 
 # Let's illustrate this with the example of a flat plate. First create the grid.
 #md # ```@setup 4.-The-Kutta-condition
+#md # ENV["GKSwstype"] = "nul"
 #md # using GridPotentialFlow
 #md # using Plots
 #md # ```

--- a/test/literate/5.-Generalized-edge-conditions.jl
+++ b/test/literate/5.-Generalized-edge-conditions.jl
@@ -17,6 +17,7 @@ If $\mathfrak{e}_{k}^T\tilde{\mathfrak{f}}^*$ lies within this range, then no ne
 
 # Let's illustrate this again with the example of a flat plate. To clearly show the effect of varying the suction parameter, we will run a simulation of the vortex shedding for a couple of time steps for three different suction parameter ranges. First we create the grid and the flate plate.
 #md # ```@setup 5.-Generalized-edge-conditions
+#md # ENV["GKSwstype"] = "nul"
 #md # using GridPotentialFlow
 #md # using Plots
 #md # ```

--- a/test/literate/6.-Force-and-the-added-mass.jl
+++ b/test/literate/6.-Force-and-the-added-mass.jl
@@ -27,6 +27,7 @@ To verify our method of calculating the impulse, we create a model of two point 
 
 # We use a rectangular grid.
 #md # ```@setup 6.-Force-and-the-added-mass
+#md # ENV["GKSwstype"] = "nul"
 #md # using GridPotentialFlow
 #md # using Plots
 #md # ```


### PR DESCRIPTION
CI documentation building in master branch failed because it took too long. This pull request reduces the simulation time of example 1 and also removes documentation build warnings related to GKS.